### PR TITLE
MB-60720 - Change the check to determine if rebalance completed

### DIFF
--- a/ctl/manager.go
+++ b/ctl/manager.go
@@ -235,7 +235,7 @@ func isBalanced(ctl *Ctl, ctlTopology *CtlTopology) bool {
 	}
 
 	lastRebStatus, err := ctl.optionsCtl.Manager.GetLastRebalanceStatus(false)
-	if err != nil || lastRebStatus == cbgt.RebStarted {
+	if err != nil || lastRebStatus != cbgt.RebCompleted {
 		return false
 	}
 


### PR DESCRIPTION
This PR refactors the check around checking if rebalance is completed by checking for completion instead of starting.